### PR TITLE
Bug fixes: IdentationError and ignored table row

### DIFF
--- a/freevpn.py
+++ b/freevpn.py
@@ -31,7 +31,7 @@ def get_password(username):
     return passw.strip() if passw else None
 
 def get_vpn_status():
-     """
+    """
     Get the status of FreeVPN Servers
     It scrapes the FreeVPN website for server status and details.
 

--- a/freevpn.py
+++ b/freevpn.py
@@ -48,7 +48,7 @@ def get_vpn_status():
     if table:
         table = table[0]
         tbody = table.tbody
-        trows = tbody.find_all('tr')[1:]
+        trows = tbody.find_all('tr')
         for row in trows:
             name = None
             loc = None


### PR DESCRIPTION
Two bugs were fixed.

1. Python was raising an IdentationError due to an extra space in one comment.

 2. The first row of the servers was ignored when slicing the rows. I think it was intended to ignore the table header, but since we're using  the tbody is not necessary to ignore first row. So I removed the **[1:]** slicing